### PR TITLE
[DP-13434] cleanup pipeline by removing unnecessary secrets and commands

### DIFF
--- a/.semaphore/publish_to_codeartifact.yml
+++ b/.semaphore/publish_to_codeartifact.yml
@@ -18,7 +18,6 @@ global_job_config :
     commands :
       - checkout
       - . vault-setup
-      - . vault-sem-get-secret cpd_gcloud
       - . vault-sem-get-secret ci-reporting
       - . vault-sem-get-secret v1/ci/kv/service-foundations/cc-mk-include
       - . vault-sem-get-secret csid_aws_credentials

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -75,7 +75,6 @@ global_job_config:
       - sem-version java 11
       - checkout
       - . vault-setup
-      - . vault-sem-get-secret cpd_gcloud
       - . vault-sem-get-secret ci-reporting
       - . vault-sem-get-secret v1/ci/kv/service-foundations/cc-mk-include
 


### PR DESCRIPTION
## Background
This PR is a followup to DP-12820 to clean up Semaphore pipelines. It brings the pipeline up to the latest standards by:
* removing unnecessary commands and secrets
* replacing deprecated commands and secrets with active ones

The vast majority of these secrets and commands are now set automatically on the Semaphore agents, so there is no need to set them specifically in the pipeline. The ones that remain are the ones that are not used globally and are specific to the pipeline's use case.

## Actions
Please approve and merge this change. If status checks are failing, please debug as necessary.
